### PR TITLE
Suppression du cron de génération de créneaux

### DIFF
--- a/cron/cronjobs
+++ b/cron/cronjobs
@@ -3,5 +3,4 @@
 40 23 * * * wget -O/dev/null http://symfony:8000/api/export/gh
 45 23 * * * wget -O/dev/null http://symfony:8000/notif/4dzq564d6/reserve
 50 23 * * * wget -O/dev/null http://symfony:8000/notif/4dzq589az6/participation
-55 23 * * * wget -O/dev/null http://symfony:8000/notif/4dzad554d6/routine
 


### PR DESCRIPTION
Le script de génération de créneaux a besoin d'être amélioré avant d'être appelé quotidiennement.